### PR TITLE
Added: support for NTLM authentication

### DIFF
--- a/lib/Catmandu/Importer/OAI.pm
+++ b/lib/Catmandu/Importer/OAI.pm
@@ -16,6 +16,10 @@ has url     => (is => 'ro', required => 1);
 has metadataPrefix => (is => 'ro' , default => sub { "oai_dc" });
 has handler => (is => 'rw', lazy => 1 , builder => 1, coerce => \&_coerce_handler );
 has xslt    => (is => 'ro', coerce => \&_coerce_xslt );
+has ntlm_host => (is => 'ro', predicate => 1);
+has ntlm_realm => (is => 'ro');
+has ntlm_user => (is => 'ro', predicate => 1);
+has ntlm_password => (is => 'ro', predicate => 1);
 has set     => (is => 'ro');
 has from    => (is => 'ro');
 has until   => (is => 'ro');
@@ -74,7 +78,12 @@ sub _coerce_xslt {
 
 sub _build_oai {
     my ($self) = @_;
-    my $agent = HTTP::OAI::Harvester->new(baseURL => $self->url, resume => 0);
+    my $agent = HTTP::OAI::Harvester->new(baseURL => $self->url, resume => 0, keep_alive => 1);
+
+    if ($self->has_ntlm_host and $self->has_ntlm_user and $self->has_ntlm_password) {
+      $agent->credentials($self->ntlm_host, $self->ntlm_realm, $self->ntlm_user, $self->ntlm_password);
+    }
+
     $agent->env_proxy;
     $agent;
 }


### PR DESCRIPTION
Basic support for NTLM integration.

* Adds 4 new switches to the importer
* NTLM authentication is done when user, host and password are set
* Optional: realm attribute

The discussion in #12 mentions the addition of explicit basic auth parameters. NTLM requires this since there are 4 properties and doesn't fit the URL spec.  We could go for a more generic solution like "--ntlm yes --user foo --pass bar --realm realm --host host" but that would make things even more complex imho.

So. Going for the straightforward road:

* Basic auth? user / pass inline in the URL struct
* NTLM? Use the dedicated attributes.

What do you think?
