### PR TITLE
Fixes #12: Credentials

### DIFF
--- a/lib/Catmandu/Importer/OAI.pm
+++ b/lib/Catmandu/Importer/OAI.pm
@@ -491,6 +491,22 @@ the importer stops can differ:
 
  ..
 
+=item realm
+
+An optional realm value. This value is used when the importer harvests from a
+repository which is secured with basic authentication through Integrated Windows
+Authentication (NTLM or Kerberos).
+
+=item username
+
+An optional username value. This value is used when the importer harvests from a
+repository which is secured with basic authentication.
+
+=item password
+
+An optional password value. This value is used when the importer harvests from a
+repository which is secured with basic authentication.
+
 =back
 
 =head1 ENVIRONMENT

--- a/lib/Catmandu/Importer/OAI.pm
+++ b/lib/Catmandu/Importer/OAI.pm
@@ -80,7 +80,7 @@ sub _coerce_xslt {
 
 sub _build_oai {
     my ($self) = @_;
-    my $agent = HTTP::OAI::Harvester->new(baseURL => $self->url, resume => 0);
+    my $agent = HTTP::OAI::Harvester->new(baseURL => $self->url, resume => 0, keep_alive => 1);
     if( $self->has_username && $self->has_password ) {
 
         my $uri = URI->new( $self->url );
@@ -91,7 +91,6 @@ sub _build_oai {
             $self->password
         );
         $agent->credentials( @credentials );
-
     }
     $agent->env_proxy;
     $agent;


### PR DESCRIPTION
Two extra commits:

* Missing keep_alive => 1  parameter in the constructor which is needed to make NTLM authentication happy.
* Documentation for the new authentication options.
