### PR TITLE
fix spelling

### DIFF
--- a/lib/Catmandu/Importer/OAI.pm
+++ b/lib/Catmandu/Importer/OAI.pm
@@ -669,7 +669,7 @@ Don't do any HTTP requests but return URLs that data would be queried from.
 
 =item strict
 
-Optional validate all parameters first against the OAI 2 spefications before
+Optional validate all parameters first against the OAI 2 specifications before
 sending it to an OAI server. Default: undef.
 
 =item xslt
@@ -685,7 +685,7 @@ Set to '0' by default.
 Internally the exponential backoff algorithm is used
 for this. This means that after every failed request the importer
 will choose a random number between 0 and 2^collision (excluded),
-and wait that number of seconds. So the actual ammount of time before
+and wait that number of seconds. So the actual amount of time before
 the importer stops can differ:
 
  first retry:


### PR DESCRIPTION

In Debian we are currently applying the following patch to
Catmandu-OAI.
We thought you might be interested in it too.


The patch is tracked in our Git repository at
https://salsa.debian.org/perl-team/modules/packages/libcatmandu-oai-perl/raw/master/debian/patches/spelling.patch

Thanks for considering,
  Mason James,
  Debian Perl Group
